### PR TITLE
splitting chronic usage into its own file

### DIFF
--- a/lib/optimist_xl.rb
+++ b/lib/optimist_xl.rb
@@ -1076,7 +1076,10 @@ class StringOption < Option
   end
 end
 
-# Option for dates.  Uses Chronic if it exists.
+# Option for dates.  No longer uses Chronic if available.
+# If chronic style dates are needed, then you may
+# require 'optimist_xl/chronic'
+
 class DateOption < Option
   register_alias :date
   def type_format ; "=<date>" ; end
@@ -1085,13 +1088,7 @@ class DateOption < Option
       pg.map do |param|
         next param if param.is_a?(Date)
         begin
-          begin
-            require 'chronic'
-            time = Chronic.parse(param)
-          rescue LoadError
-            # chronic is not available
-          end
-          time ? Date.new(time.year, time.month, time.day) : Date.parse(param)
+          Date.parse(param)
         rescue ArgumentError
           raise CommandlineError, "option '#{self.name}' needs a date"
         end

--- a/lib/optimist_xl/chronic.rb
+++ b/lib/optimist_xl/chronic.rb
@@ -1,0 +1,36 @@
+require 'chronic'
+
+
+module OptimistXL
+
+# Option for dates using Chronic gem.
+# Mainly for compatibility with Optimist.
+# Use of Chronic switches to United States formatted
+# dates (MM/DD/YYYY) as opposed to DD/MM/YYYY
+
+class ChronicDateOption < Option
+  register_alias :chronic_date
+  register_alias :'chronic::date'
+  def type_format ; "=<date>" ; end
+  def parse(paramlist, _neg_given)
+    paramlist.map do |pg|
+      pg.map do |param|
+        parse_date_param(param)
+      end
+    end
+  end
+
+  private
+  def parse_date_param(param)
+    if param.respond_to?(:year) and param.respond_to?(:month) and param.respond_to(:day)
+      return Date.new(param.year, param.month, param.day)
+    end
+    time = Chronic.parse(param)
+    time ? Date.new(time.year, time.month, time.day) : Date.parse(param)
+  rescue ArgumentError
+    raise CommandlineError, "option '#{self.name}' needs a valid date"
+  end
+  
+end
+
+end

--- a/test/optimist_xl/parser_test.rb
+++ b/test/optimist_xl/parser_test.rb
@@ -556,10 +556,17 @@ Options:
     @p.opt :arg, "desc", :type => :date, :short => 'd'
     opts = @p.parse(['-d', 'Jan 4, 2007'])
     assert_equal Date.civil(2007, 1, 4), opts[:arg]
-    opts = @p.parse(['-d', 'today'])
-    assert_equal Date.today, opts[:arg]
   end
 
+  def test_chronic_date_formatting
+    # note: only works with chronic gem
+    require 'optimist_xl/chronic'
+    @p.opt :arg, "chronic", :type => :chronic_date, :short => 'd'
+    opts = @p.parse(['-d', 'today'])
+    assert_equal Date.today, opts[:arg]
+  rescue LoadError
+  end
+  
   def test_short_options_cant_be_numeric
     assert_raises(ArgumentError) { @p.opt :arg, "desc", :short => "-1" }
     @p.opt :a1b, "desc"
@@ -984,6 +991,28 @@ Options:
     opts = @p.parse []
     assert_equal temp, opts[:arg3]
 
+    opts = @p.parse %w(--arg 2010/05/01)
+    assert_kind_of Date, opts[:arg]
+    assert_equal Date.new(2010, 5, 1), opts[:arg]
+
+    opts = @p.parse %w(--arg2 2010/9/13)
+    assert_kind_of Date, opts[:arg2]
+    assert_equal Date.new(2010, 9, 13), opts[:arg2]
+
+    opts = @p.parse %w(--arg3)
+    assert_equal temp, opts[:arg3]
+  end
+
+  def test_chronic_date_arg_type
+    require 'optimist_xl/chronic'
+    temp = Date.new
+    @p.opt :arg, 'desc', :type => :chronic_date
+    @p.opt :arg2, 'desc', :type => Chronic::Date
+    @p.opt :arg3, 'desc', :default => temp
+
+    opts = @p.parse []
+    assert_equal temp, opts[:arg3]
+
     opts = @p.parse %w(--arg 5/1/2010)
     assert_kind_of Date, opts[:arg]
     assert_equal Date.new(2010, 5, 1), opts[:arg]
@@ -994,7 +1023,8 @@ Options:
 
     opts = @p.parse %w(--arg3)
     assert_equal temp, opts[:arg3]
-  end
+  rescue LoadError
+  end    
 
   def test_unknown_arg_class_type
     assert_raises ArgumentError do


### PR DESCRIPTION
Splitting chronic usage into its own file that has to be separately loaded.  
The tests for chronic specific date-times now only run if chronic is loadable and arg uses Chronic::Date or :chronic_date type.

This is non-backward compatible behavior with https://github.com/ManageIQ/optimist