### PR TITLE
fixing warnings found with ruby 2.6.3 and 2.7.0. 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@ rvm:
   - "2.2"
   - "2.3.4"
   - "2.5.1"
+  - "2.6.3"
+  - "2.7.0"
   - jruby-head
 matrix:
   allow_failures:

--- a/README.md
+++ b/README.md
@@ -20,7 +20,6 @@ for everything you don't specify.
 ## Features
 
 - Dirt-simple usage.
-- Single file. Throw it in lib/ if you don't want to make it a Rubygem dependency.
 - Sensible defaults. No tweaking necessary, much tweaking possible.
 - Support for long options, short options, subcommands, and automatic type validation and
   conversion.
@@ -51,7 +50,7 @@ Permitted options allow specifying valid choices for an option using lists, rang
 
 ## Requirements
 
-* Ruby 2.0+
+* Ruby 2.2+
 * A burning desire to write less code.
 
 ## Install

--- a/lib/optimist_xl.rb
+++ b/lib/optimist_xl.rb
@@ -261,7 +261,7 @@ class Parser
   ## If we hit a complete match, then use that, otherwise see how many long-options partially match.
   ## If only one partially matches, then we can safely use that.
   ## Otherwise, we raise an error that the partially given option was ambiguous.
-  def perform_inexact_match (arg, partial_match)  # :nodoc:
+  def perform_inexact_match(arg, partial_match)  # :nodoc:
     return @long[partial_match] if @long.has_key?(partial_match)
     partially_matched_keys = @long.keys.grep(/^#{partial_match}/)
     return case partially_matched_keys.size

--- a/test/optimist_xl/parser_test.rb
+++ b/test/optimist_xl/parser_test.rb
@@ -1172,7 +1172,7 @@ Options:
     opts = newp.parse %w(--lib 5 --ev bar)
     assert_equal 5, opts[:liberation]
     assert_equal 'bar', opts[:evaluate]
-    assert_equal nil, opts[:eval]
+    assert_nil opts[:eval]
   end
   
   def test_exact_match

--- a/test/optimist_xl/subcommands_test.rb
+++ b/test/optimist_xl/subcommands_test.rb
@@ -19,13 +19,13 @@ module SubcommandTests
     end
     sio = StringIO.new "w"
     @p.educate sio
-    assert_match /list\s+show the list/, sio.string
-    assert_match /create\s*\n/, sio.string
+    assert_match(/list\s+show the list/, sio.string)
+    assert_match(/create\s*\n/, sio.string)
   end
 
   # fails when invalid param given
   def test_subcommand_invalid_opt
-    assert_stderr_errmatch(/unknown argument '--boom'/) do
+    assert_raises_errmatch(OptimistXL::CommandlineError, /unknown argument '--boom'/) do
       @p.parse(%w(--boom))
     end
   end
@@ -51,8 +51,8 @@ module SubcommandTests
 
     sio = StringIO.new "w"
     err.parser.educate sio
-    assert_match /all.*list all the things/, sio.string
-    assert_match /help.*Show this message/, sio.string
+    assert_match(/all.*list all the things/, sio.string)
+    assert_match(/help.*Show this message/, sio.string)
   end
   
   def test_subcommand_help_subcmd2
@@ -61,13 +61,13 @@ module SubcommandTests
     end
     sio = StringIO.new "w"
     err.parser.educate sio
-    assert_match /partial.*create a partial thing/, sio.string
-    assert_match /name.*creation name/, sio.string
-    assert_match /help.*Show this message/, sio.string
+    assert_match(/partial.*create a partial thing/, sio.string)
+    assert_match(/name.*creation name/, sio.string)
+    assert_match(/help.*Show this message/, sio.string)
   end
   
   # fails when valid subcommand given with invalid param
-  def test_subcommand_invalid_opt
+  def test_subcommand_invalid_subopt
     #assert_raises_errmatch(OptimistXL::CommandlineError, /unknown argument '--foo' for command 'list'/) do
     assert_raises_errmatch(OptimistXL::CommandlineError, /unknown argument '--foo'/) do
       @p.parse(%w(list --foo))


### PR DESCRIPTION
fixed warnings with ruby 2.6.3 and 2.7.0
validated clean tests with ruby 2.3.6
updated documentation to remove the 'all in one file' line.
updated travis.yml to use ruby 2.6 and 2.7
