### PR TITLE
Fixing bug with missing option

### DIFF
--- a/lib/optimist_xl.rb
+++ b/lib/optimist_xl.rb
@@ -819,7 +819,11 @@ class LongNames
   def names
     [long] + @alts
   end
-  
+
+  def to_s
+    @long
+  end
+
 end
 
 class ShortNames


### PR DESCRIPTION
Implementing LongNames#to_s to get a human readable error message when a required option is missing.

Before:
```shell
ruby examples/medium_example.rb 
# Error: option --#<OptimistXL::LongNames:0x0000000127b25840> must be specified.
# Try --help for help.
```

Fixed version:
```shell
ruby examples/medium_example.rb                    
# Error: option --config must be specified.
# Try --help for help.
```